### PR TITLE
Add HandIdentifier class capable to identify Straight Flush and Four of a Kind hands

### DIFF
--- a/katas/pokerhands/jose/handidentifier.js
+++ b/katas/pokerhands/jose/handidentifier.js
@@ -1,5 +1,5 @@
-import { FourOfAKind } from './patterns/FourOfAKind';
-import { StraightFlush } from './patterns/StraightFlush';
+import { FourOfAKind } from './patterns/fourofakind';
+import { StraightFlush } from './patterns/straightflush';
 
 export class HandIdentifier {
     #patterns = [

--- a/katas/pokerhands/jose/handidentifier.js
+++ b/katas/pokerhands/jose/handidentifier.js
@@ -1,19 +1,20 @@
-import { HandChecker } from './handchecker';
-import { ValueCounter } from './valuecounter';
+import { FourOfAKind } from './patterns/FourOfAKind';
+import { StraightFlush } from './patterns/StraightFlush';
 
 export class HandIdentifier {
-    #checker = new HandChecker();
-
-    #counter = new ValueCounter();
+    #patterns = [
+        new StraightFlush(),
+        new FourOfAKind()
+    ];
 
     identify(pokerhand) {
         let handPattern = undefined;
-        const count = this.#counter.countRepeatedValues(pokerhand);
-        if (this.#checker.hasAllCardsSameSuit(pokerhand) &&
-           this.#checker.hasConsecutiveValues(pokerhand)) {
-            handPattern = 'Straight Flush';
-        } else if (Object.values(count).includes(4)) {
-            handPattern = 'Four of a Kind';
+        for (let index = 0; index < this.#patterns.length; index++) {
+            const pattern = this.#patterns[index];
+            if (pattern.match(pokerhand)) {
+                handPattern = pattern.name;
+                break;
+            }
         }
         return handPattern;
     }

--- a/katas/pokerhands/jose/handidentifier.js
+++ b/katas/pokerhands/jose/handidentifier.js
@@ -1,13 +1,19 @@
 import { HandChecker } from './handchecker';
+import { ValueCounter } from './valuecounter';
 
 export class HandIdentifier {
     #checker = new HandChecker();
 
+    #counter = new ValueCounter();
+
     identify(pokerhand) {
         let handPattern = undefined;
+        const count = this.#counter.countRepeatedValues(pokerhand);
         if (this.#checker.hasAllCardsSameSuit(pokerhand) &&
            this.#checker.hasConsecutiveValues(pokerhand)) {
             handPattern = 'Straight Flush';
+        } else if (Object.values(count).includes(4)) {
+            handPattern = 'Four of a Kind';
         }
         return handPattern;
     }

--- a/katas/pokerhands/jose/handidentifier.js
+++ b/katas/pokerhands/jose/handidentifier.js
@@ -1,0 +1,14 @@
+import { HandChecker } from './handchecker';
+
+export class HandIdentifier {
+    #checker = new HandChecker();
+
+    identify(pokerhand) {
+        let handPattern = undefined;
+        if (this.#checker.hasAllCardsSameSuit(pokerhand) &&
+           this.#checker.hasConsecutiveValues(pokerhand)) {
+            handPattern = 'Straight Flush';
+        }
+        return handPattern;
+    }
+}

--- a/katas/pokerhands/jose/handidentifier.test.js
+++ b/katas/pokerhands/jose/handidentifier.test.js
@@ -29,4 +29,31 @@ describe('Hand Identifier tests', () => {
         notStraightFlushHand.addCard(new Card('C', CardValue.Nine));
         expect(identifier.identify(notStraightFlushHand)).not.toBe('Straight Flush');
     });
+
+    it('should be able of identify a four of a kind pokerhand', () => {
+        const identifier = new HandIdentifier();
+        const fourOfAKindHand = new PokerHand();
+        fourOfAKindHand.addCard(new Card('C', CardValue.Five));
+        fourOfAKindHand.addCard(new Card('H', CardValue.Five));
+        fourOfAKindHand.addCard(new Card('S', CardValue.Five));
+        fourOfAKindHand.addCard(new Card('D', CardValue.Five));
+        fourOfAKindHand.addCard(new Card('C', CardValue.Nine));
+        expect(identifier.identify(fourOfAKindHand)).toBe('Four of a Kind');
+
+        let notFourOfAKind = new PokerHand();
+        notFourOfAKind.addCard(new Card('C', CardValue.Five));
+        notFourOfAKind.addCard(new Card('H', CardValue.Six));
+        notFourOfAKind.addCard(new Card('C', CardValue.Seven));
+        notFourOfAKind.addCard(new Card('C', CardValue.Eight));
+        notFourOfAKind.addCard(new Card('C', CardValue.Nine));
+        expect(identifier.identify(notFourOfAKind)).not.toBe('Four of a Kind');
+
+        notFourOfAKind = new PokerHand();
+        notFourOfAKind.addCard(new Card('C', CardValue.Five));
+        notFourOfAKind.addCard(new Card('C', CardValue.Six));
+        notFourOfAKind.addCard(new Card('C', CardValue.Jack));
+        notFourOfAKind.addCard(new Card('C', CardValue.Eight));
+        notFourOfAKind.addCard(new Card('C', CardValue.Nine));
+        expect(identifier.identify(notFourOfAKind)).not.toBe('Four of a Kind');
+    });
 });

--- a/katas/pokerhands/jose/handidentifier.test.js
+++ b/katas/pokerhands/jose/handidentifier.test.js
@@ -1,0 +1,32 @@
+import { Card, CardValue } from './card';
+import { HandIdentifier } from './handidentifier';
+import { PokerHand } from './pokerhand';
+
+describe('Hand Identifier tests', () => {
+    it('should be able of identify a straight flush pokerhand', () => {
+        const identifier = new HandIdentifier();
+        const straightFlushHand = new PokerHand();
+        straightFlushHand.addCard(new Card('C', CardValue.Five));
+        straightFlushHand.addCard(new Card('C', CardValue.Six));
+        straightFlushHand.addCard(new Card('C', CardValue.Seven));
+        straightFlushHand.addCard(new Card('C', CardValue.Eight));
+        straightFlushHand.addCard(new Card('C', CardValue.Nine));
+        expect(identifier.identify(straightFlushHand)).toBe('Straight Flush');
+
+        let notStraightFlushHand = new PokerHand();
+        notStraightFlushHand.addCard(new Card('C', CardValue.Five));
+        notStraightFlushHand.addCard(new Card('H', CardValue.Six));
+        notStraightFlushHand.addCard(new Card('C', CardValue.Seven));
+        notStraightFlushHand.addCard(new Card('C', CardValue.Eight));
+        notStraightFlushHand.addCard(new Card('C', CardValue.Nine));
+        expect(identifier.identify(notStraightFlushHand)).not.toBe('Straight Flush');
+
+        notStraightFlushHand = new PokerHand();
+        notStraightFlushHand.addCard(new Card('C', CardValue.Five));
+        notStraightFlushHand.addCard(new Card('C', CardValue.Six));
+        notStraightFlushHand.addCard(new Card('C', CardValue.Jack));
+        notStraightFlushHand.addCard(new Card('C', CardValue.Eight));
+        notStraightFlushHand.addCard(new Card('C', CardValue.Nine));
+        expect(identifier.identify(notStraightFlushHand)).not.toBe('Straight Flush');
+    });
+});

--- a/katas/pokerhands/jose/patterns/fourofakind.js
+++ b/katas/pokerhands/jose/patterns/fourofakind.js
@@ -1,0 +1,12 @@
+import { HandPattern } from './HandPattern';
+
+export class FourOfAKind extends HandPattern {
+    match(pokerhand) {
+        const count = this.counter.countRepeatedValues(pokerhand);
+        return Object.values(count).includes(4);
+    }
+
+    get name() {
+        return 'Four of a Kind';
+    }
+}

--- a/katas/pokerhands/jose/patterns/fourofakind.js
+++ b/katas/pokerhands/jose/patterns/fourofakind.js
@@ -1,4 +1,4 @@
-import { HandPattern } from './HandPattern';
+import { HandPattern } from './handpattern';
 
 export class FourOfAKind extends HandPattern {
     match(pokerhand) {

--- a/katas/pokerhands/jose/patterns/handpattern.js
+++ b/katas/pokerhands/jose/patterns/handpattern.js
@@ -1,0 +1,24 @@
+import { HandChecker } from '../handchecker';
+import { ValueCounter } from '../valuecounter';
+
+export class HandPattern {
+    #checker = new HandChecker();
+
+    #counter = new ValueCounter();
+
+    match(pokerhand) {
+        throw new Error(`abstract, must implement match method ${pokerhand}`);
+    }
+
+    get name() {
+        throw new Error('abstract, must implement name method');
+    }
+
+    get checker() {
+        return this.#checker;
+    }
+
+    get counter() {
+        return this.#counter;
+    }
+}

--- a/katas/pokerhands/jose/patterns/straightflush.js
+++ b/katas/pokerhands/jose/patterns/straightflush.js
@@ -1,4 +1,4 @@
-import { HandPattern } from './HandPattern';
+import { HandPattern } from './handpattern';
 
 export class StraightFlush extends HandPattern {
     match(pokerhand) {

--- a/katas/pokerhands/jose/patterns/straightflush.js
+++ b/katas/pokerhands/jose/patterns/straightflush.js
@@ -1,0 +1,12 @@
+import { HandPattern } from './HandPattern';
+
+export class StraightFlush extends HandPattern {
+    match(pokerhand) {
+        return this.checker.hasAllCardsSameSuit(pokerhand) &&
+               this.checker.hasConsecutiveValues(pokerhand);
+    }
+
+    get name() {
+        return 'Straight Flush';
+    }
+}


### PR DESCRIPTION
This implementation initially started as a group of (potentially harmful) if-else blocks, then it was refactored to use abstract HandPattern, where StraightFlush and FourOfAKind inherited and created polymorphism to match any type of pattern that identifier need to find